### PR TITLE
[USD-162] cmap parse patch

### DIFF
--- a/example/capjoin/main.go
+++ b/example/capjoin/main.go
@@ -3,7 +3,9 @@
 // FreeType License or the GNU General Public License version 2 (or
 // any later version), both of which can be found in the LICENSE file.
 
+//go:build example
 // +build example
+
 //
 // This build tag means that "go install github.com/golang/freetype/..."
 // doesn't install this example program. Use "go run main.go" to run it or "go
@@ -21,7 +23,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/freetype/raster"
+	"github.com/unidoc/freetype/raster"
 	"golang.org/x/image/math/fixed"
 )
 

--- a/example/drawer/main.go
+++ b/example/drawer/main.go
@@ -3,7 +3,9 @@
 // FreeType License or the GNU General Public License version 2 (or
 // any later version), both of which can be found in the LICENSE file.
 
+//go:build example
 // +build example
+
 //
 // This build tag means that "go install github.com/golang/freetype/..."
 // doesn't install this example program. Use "go run main.go" to run it or "go
@@ -24,7 +26,7 @@ import (
 	"math"
 	"os"
 
-	"github.com/golang/freetype/truetype"
+	"github.com/unidoc/freetype/truetype"
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )

--- a/example/freetype/main.go
+++ b/example/freetype/main.go
@@ -3,7 +3,9 @@
 // FreeType License or the GNU General Public License version 2 (or
 // any later version), both of which can be found in the LICENSE file.
 
+//go:build example
 // +build example
+
 //
 // This build tag means that "go install github.com/golang/freetype/..."
 // doesn't install this example program. Use "go run main.go" to run it or "go
@@ -23,7 +25,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/freetype"
+	"github.com/unidoc/freetype"
 	"golang.org/x/image/font"
 )
 

--- a/example/gamma/main.go
+++ b/example/gamma/main.go
@@ -3,7 +3,9 @@
 // FreeType License or the GNU General Public License version 2 (or
 // any later version), both of which can be found in the LICENSE file.
 
+//go:build example
 // +build example
+
 //
 // This build tag means that "go install github.com/golang/freetype/..."
 // doesn't install this example program. Use "go run main.go" to run it or "go
@@ -20,7 +22,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/freetype/raster"
+	"github.com/unidoc/freetype/raster"
 	"golang.org/x/image/math/fixed"
 )
 

--- a/example/genbasicfont/main.go
+++ b/example/genbasicfont/main.go
@@ -3,7 +3,9 @@
 // FreeType License or the GNU General Public License version 2 (or
 // any later version), both of which can be found in the LICENSE file.
 
+//go:build example
 // +build example
+
 //
 // This build tag means that "go install github.com/golang/freetype/..."
 // doesn't install this example program. Use "go run main.go" to run it or "go
@@ -26,7 +28,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/golang/freetype/truetype"
+	"github.com/unidoc/freetype/truetype"
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )

--- a/example/raster/main.go
+++ b/example/raster/main.go
@@ -3,7 +3,9 @@
 // FreeType License or the GNU General Public License version 2 (or
 // any later version), both of which can be found in the LICENSE file.
 
+//go:build example
 // +build example
+
 //
 // This build tag means that "go install github.com/golang/freetype/..."
 // doesn't install this example program. Use "go run main.go" to run it or "go
@@ -21,7 +23,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/freetype/raster"
+	"github.com/unidoc/freetype/raster"
 	"golang.org/x/image/math/fixed"
 )
 

--- a/example/round/main.go
+++ b/example/round/main.go
@@ -3,7 +3,9 @@
 // FreeType License or the GNU General Public License version 2 (or
 // any later version), both of which can be found in the LICENSE file.
 
+//go:build example
 // +build example
+
 //
 // This build tag means that "go install github.com/golang/freetype/..."
 // doesn't install this example program. Use "go run main.go" to run it or "go
@@ -27,7 +29,7 @@ import (
 	"math"
 	"os"
 
-	"github.com/golang/freetype/raster"
+	"github.com/unidoc/freetype/raster"
 	"golang.org/x/image/math/fixed"
 )
 

--- a/example/truetype/main.go
+++ b/example/truetype/main.go
@@ -3,7 +3,9 @@
 // FreeType License or the GNU General Public License version 2 (or
 // any later version), both of which can be found in the LICENSE file.
 
+//go:build example
 // +build example
+
 //
 // This build tag means that "go install github.com/golang/freetype/..."
 // doesn't install this example program. Use "go run main.go" to run it or "go
@@ -17,7 +19,7 @@ import (
 	"io/ioutil"
 	"log"
 
-	"github.com/golang/freetype/truetype"
+	"github.com/unidoc/freetype/truetype"
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )

--- a/freetype.go
+++ b/freetype.go
@@ -10,7 +10,6 @@ package freetype // import "github.com/golang/freetype"
 
 import (
 	"errors"
-	"fmt"
 	"image"
 	"image/draw"
 
@@ -45,7 +44,6 @@ type cacheEntry struct {
 // It is provided here so that code that imports this package doesn't need
 // to also include the freetype/truetype package.
 func ParseFont(b []byte) (*truetype.Font, error) {
-	fmt.Printf("parsefont")
 	return truetype.Parse(b)
 }
 
@@ -200,7 +198,6 @@ func (c *Context) rasterize(glyph truetype.Index, fx, fy fixed.Int26_6) (
 func (c *Context) glyph(glyph truetype.Index, p fixed.Point26_6) (
 	fixed.Int26_6, *image.Alpha, image.Point, error) {
 
-	fmt.Println("glyph index ", glyph)
 	// Split p.X and p.Y into their integer and fractional parts.
 	ix, fx := int(p.X>>6), p.X&0x3f
 	iy, fy := int(p.Y>>6), p.Y&0x3f

--- a/freetype.go
+++ b/freetype.go
@@ -13,8 +13,8 @@ import (
 	"image"
 	"image/draw"
 
-	"github.com/golang/freetype/raster"
-	"github.com/golang/freetype/truetype"
+	"github.com/unidoc/freetype/raster"
+	"github.com/unidoc/freetype/truetype"
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )

--- a/freetype.go
+++ b/freetype.go
@@ -10,6 +10,7 @@ package freetype // import "github.com/golang/freetype"
 
 import (
 	"errors"
+	"fmt"
 	"image"
 	"image/draw"
 
@@ -44,6 +45,7 @@ type cacheEntry struct {
 // It is provided here so that code that imports this package doesn't need
 // to also include the freetype/truetype package.
 func ParseFont(b []byte) (*truetype.Font, error) {
+	fmt.Printf("parsefont")
 	return truetype.Parse(b)
 }
 
@@ -198,6 +200,7 @@ func (c *Context) rasterize(glyph truetype.Index, fx, fy fixed.Int26_6) (
 func (c *Context) glyph(glyph truetype.Index, p fixed.Point26_6) (
 	fixed.Int26_6, *image.Alpha, image.Point, error) {
 
+	fmt.Println("glyph index ", glyph)
 	// Split p.X and p.Y into their integer and fractional parts.
 	ix, fx := int(p.X>>6), p.X&0x3f
 	iy, fy := int(p.Y>>6), p.Y&0x3f

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/unidoc/freetype
 
 go 1.14
 
-require (
-	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
-)
+require golang.org/x/image v0.0.0-20211028202545-6944b10bf410

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
-module github.com/golang/freetype
+module github.com/unidoc/freetype
 
-go 1.14
+go 1.17
 
-require golang.org/x/image v0.0.0-20211028202545-6944b10bf410
+replace github.com/golang/freetype => ../freetype
+
+require (
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
+	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,7 @@ module github.com/unidoc/freetype
 
 go 1.17
 
-replace github.com/golang/freetype => ../freetype
-
 require (
-	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
-	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/unidoc/freetype
 
-go 1.17
+go 1.14
 
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/golang/freetype
+
+go 1.14
+
+require golang.org/x/image v0.0.0-20211028202545-6944b10bf410

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
-github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/truetype/face.go
+++ b/truetype/face.go
@@ -9,7 +9,7 @@ import (
 	"image"
 	"math"
 
-	"github.com/golang/freetype/raster"
+	"github.com/unidoc/freetype/raster"
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )

--- a/truetype/face.go
+++ b/truetype/face.go
@@ -342,7 +342,17 @@ func (a *face) GlyphBounds(r rune) (bounds fixed.Rectangle26_6, advance fixed.In
 }
 
 func (a *face) GlyphAdvance(r rune) (advance fixed.Int26_6, ok bool) {
-	if err := a.glyphBuf.Load(a.f, a.scale, a.index(r), a.hinting); err != nil {
+	idx := a.index(r)
+	if len(a.f.cmGlyphIDArray) > 0 {
+		for i := 0; i < len(a.f.cmGlyphIDArray)-1; i++ {
+			if uint8(idx) == a.f.cmGlyphIDArray[i] {
+				idx = a.index(rune(i))
+				break
+			}
+		}
+	}
+
+	if err := a.glyphBuf.Load(a.f, a.scale, idx, a.hinting); err != nil {
 		return 0, false
 	}
 	return a.glyphBuf.AdvanceWidth, true

--- a/truetype/truetype.go
+++ b/truetype/truetype.go
@@ -290,8 +290,6 @@ func (f *Font) parseCmap() error {
 					}
 
 					if gid > 0 {
-						//b := runeDecoder.ToBytes(uint32(c))
-						//r := runeDecoder.DecodeRune(b)
 						if int(gid) >= int(f.nGlyph) {
 							return FormatError("out of bounds")
 						}
@@ -303,7 +301,6 @@ func (f *Font) parseCmap() error {
 			f.charcodeToGID = charcodeMap
 		}
 		return nil
-
 	case cmapFormat12:
 		if u16(f.cmap, offset+2) != 0 {
 			return FormatError(fmt.Sprintf("cmap format: % x", f.cmap[offset:offset+4]))

--- a/truetype/truetype.go
+++ b/truetype/truetype.go
@@ -461,7 +461,7 @@ func (f *Font) Name(id NameID) string {
 	return string(dst)
 }
 
-// Index returns a Font's index for the given rune.
+// HasShortCmap returns true if font use simple encoding.
 func (f *Font) HasShortCmap() bool {
 	return f.hasShortCmap
 }

--- a/truetype/truetype.go
+++ b/truetype/truetype.go
@@ -59,6 +59,7 @@ const (
 	// specified at https://www.microsoft.com/typography/otspec/name.htm
 	unicodeEncodingBMPOnly  = 0x00000003 // PID = 0 (Unicode), PSID = 3 (Unicode 2.0 BMP Only)
 	unicodeEncodingFull     = 0x00000004 // PID = 0 (Unicode), PSID = 4 (Unicode 2.0 Full Repertoire)
+	macintoshSimpleEncoding = 0x00010000 // PID = 1 (Macintosh), PSID = 1 (Macintosh)
 	microsoftSymbolEncoding = 0x00030000 // PID = 3 (Microsoft), PSID = 0 (Symbol)
 	microsoftUCS2Encoding   = 0x00030001 // PID = 3 (Microsoft), PSID = 1 (UCS-2)
 	microsoftUCS4Encoding   = 0x0003000a // PID = 3 (Microsoft), PSID = 10 (UCS-4)
@@ -143,10 +144,12 @@ func parseSubtables(table []byte, name string, offset, size int, pred func([]byt
 		pidPsid := u32(table, offset)
 		// We prefer the Unicode cmap encoding. Failing to find that, we fall
 		// back onto the Microsoft cmap encoding.
-		if pidPsid == unicodeEncodingBMPOnly || pidPsid == unicodeEncodingFull {
+		if pidPsid == macintoshSimpleEncoding {
 			bestOffset, bestPID, ok = offset, pidPsid>>16, true
 			break
-
+		} else if pidPsid == unicodeEncodingBMPOnly || pidPsid == unicodeEncodingFull {
+			bestOffset, bestPID, ok = offset, pidPsid>>16, true
+			break
 		} else if pidPsid == microsoftSymbolEncoding ||
 			pidPsid == microsoftUCS2Encoding ||
 			pidPsid == microsoftUCS4Encoding {
@@ -190,10 +193,13 @@ type Font struct {
 	bounds                  fixed.Rectangle26_6 // In FUnits.
 	// Values from the maxp section.
 	maxTwilightPoints, maxStorage, maxFunctionDefs, maxStackElements uint16
+	// USD-162 issue, cmap glyph id array.
+	cmGlyphIDArray []uint8
 }
 
 func (f *Font) parseCmap() error {
 	const (
+		cmapFormat0         = 0
 		cmapFormat4         = 4
 		cmapFormat12        = 12
 		languageIndependent = 0
@@ -210,6 +216,13 @@ func (f *Font) parseCmap() error {
 
 	cmapFormat := u16(f.cmap, offset)
 	switch cmapFormat {
+	case cmapFormat0:
+		glyphIDArray := make([]uint8, 256)
+		for i := 0; i < 256; i++ {
+			glyphIDArray[i] = f.cmap[offset+6+i]
+		}
+		f.cmGlyphIDArray = glyphIDArray
+		return nil
 	case cmapFormat4:
 		language := u16(f.cmap, offset+4)
 		if language != languageIndependent {
@@ -391,6 +404,11 @@ func (f *Font) FUnitsPerEm() int32 {
 // Index returns a Font's index for the given rune.
 func (f *Font) Index(x rune) Index {
 	c := uint32(x)
+	fmt.Printf("Index: c: %d, len: %d\n", c, len(f.cmGlyphIDArray))
+	if len(f.cmGlyphIDArray) > int(c) {
+		val := f.cmGlyphIDArray[c]
+		return Index(val)
+	}
 	for i, j := 0, len(f.cm); i < j; {
 		h := i + (j-i)/2
 		cm := &f.cm[h]

--- a/truetype/truetype.go
+++ b/truetype/truetype.go
@@ -134,7 +134,7 @@ func parseSubtables(table []byte, name string, offset, size int, pred func([]byt
 	if len(table) < size*nSubtables+offset {
 		return 0, 0, FormatError(name + " too short")
 	}
-	ok := false
+	bestScore := -1
 	for i := 0; i < nSubtables; i, offset = i+1, offset+size {
 		if pred != nil && !pred(table[offset:]) {
 			continue
@@ -144,21 +144,24 @@ func parseSubtables(table []byte, name string, offset, size int, pred func([]byt
 		pidPsid := u32(table, offset)
 		// We prefer the Unicode cmap encoding. Failing to find that, we fall
 		// back onto the Microsoft cmap encoding.
-		if pidPsid == macintoshSimpleEncoding {
-			bestOffset, bestPID, ok = offset, pidPsid>>16, true
-			break
-		} else if pidPsid == unicodeEncodingBMPOnly || pidPsid == unicodeEncodingFull {
-			bestOffset, bestPID, ok = offset, pidPsid>>16, true
-			break
+		// And we prefer full/UCS4 encoding over BMP/UCS2. So the priority goes:
+		//    unicodeEncodingFull > macintoshSimpleEncoding > microsoftUCS4Encoding > unicodeEncodingBMPOnly > macintoshSimpleEncoding > microsoftUCS2Encoding > microsoftSymbolEncoding
+		// It is in accord with the Psid part.
+		score := int(pidPsid & 0xFFFF)
+		if score <= bestScore {
+			continue
+		}
+		if pidPsid == unicodeEncodingBMPOnly || pidPsid == unicodeEncodingFull {
+			bestOffset, bestPID, bestScore = offset, pidPsid>>16, score
+		} else if pidPsid == macintoshSimpleEncoding {
+			bestOffset, bestPID, bestScore = offset, pidPsid>>16, score
 		} else if pidPsid == microsoftSymbolEncoding ||
 			pidPsid == microsoftUCS2Encoding ||
 			pidPsid == microsoftUCS4Encoding {
-
-			bestOffset, bestPID, ok = offset, pidPsid>>16, true
-			// We don't break out of the for loop, so that Unicode can override Microsoft.
+			bestOffset, bestPID, bestScore = offset, pidPsid>>16, score
 		}
 	}
-	if !ok {
+	if bestScore < 0 {
 		return 0, 0, UnsupportedError(name + " encoding")
 	}
 	return bestOffset, bestPID, nil
@@ -195,6 +198,7 @@ type Font struct {
 	maxTwilightPoints, maxStorage, maxFunctionDefs, maxStackElements uint16
 	// USD-162 issue, cmap glyph id array.
 	cmGlyphIDArray []uint8
+	hasShortCmap   bool
 }
 
 func (f *Font) parseCmap() error {
@@ -222,6 +226,7 @@ func (f *Font) parseCmap() error {
 			glyphIDArray[i] = f.cmap[offset+6+i]
 		}
 		f.cmGlyphIDArray = glyphIDArray
+		f.hasShortCmap = true
 		return nil
 	case cmapFormat4:
 		language := u16(f.cmap, offset+4)
@@ -404,7 +409,6 @@ func (f *Font) FUnitsPerEm() int32 {
 // Index returns a Font's index for the given rune.
 func (f *Font) Index(x rune) Index {
 	c := uint32(x)
-	fmt.Printf("Index: c: %d, len: %d\n", c, len(f.cmGlyphIDArray))
 	if len(f.cmGlyphIDArray) > int(c) {
 		val := f.cmGlyphIDArray[c]
 		return Index(val)
@@ -455,6 +459,11 @@ func (f *Font) Name(id NameID) string {
 		}
 	}
 	return string(dst)
+}
+
+// Index returns a Font's index for the given rune.
+func (f *Font) HasShortCmap() bool {
+	return f.hasShortCmap
 }
 
 func printable(r uint16) byte {


### PR DESCRIPTION
[USD-162] Simple font with subtable format(1,0) Macintosh Simple Encoding and cmap format0 parse implementation.
[USD-168] Simple font with subtabel format(3,0) Microsoft Symbol Encoding and cmap format4 patch, use unitype implementation if the freetype can't parse the cmap index correctly.