### PR TITLE
[US-168] Added a check for cmap format 4 

### DIFF
--- a/truetype/truetype.go
+++ b/truetype/truetype.go
@@ -312,6 +312,9 @@ func (f *Font) parseCmap() error {
 					}
 				}
 			}
+			if len(charcodeMap) < 1 {
+				return FormatError("no charcode map or cmap indexes")
+			}
 			f.charcodeToGID = charcodeMap
 		}
 		f.hasCmap = true


### PR DESCRIPTION
Added a check for cmap format 4 - if there are no cmap indexes or charcode map - return the error. In this case we won't be able to use the embedded font for rendering, need to look for replacement.

JIRA ticket: https://unidoc.atlassian.net/browse/US-168

Tested with we-dms.pdf. It is rendered ok with this change in freetype and no other changes from unipdf side. 