### PR TITLE
[US-196] Fix for charcodeToGid check.

### DIFF
--- a/truetype/truetype.go
+++ b/truetype/truetype.go
@@ -497,7 +497,8 @@ func (f *Font) Index(x rune) Index {
 		return Index(val)
 	}
 
-	if len(f.charcodeToGID) > int(c) {
+	if len(f.charcodeToGID) > 0 && c < 256 {
+		// charcodeToGID is not empty and c is in 0..255 uint8 range
 		val := f.charcodeToGID[uint8(c)]
 		return Index(val)
 	}


### PR DESCRIPTION
After merging previous freetype PR

https://github.com/unidoc/freetype/pull/6

I found regression on two files from unipdf testset: t-3b.pdf and 376133-stripped.pdf

I corrected the check for charcodeToGid and with this change these rendering tests are passing. 