### PR TITLE
[US-1446] Fix OOB panics in TrueType glyph loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,81 @@
+### macOS
+# Finder metadata
+.DS_Store
+
+# Thumbnails
+._*
+
+# Custom folder icons
+Icon
+
+# Volume root files
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+### Windows
+# Windows thumbnail cache files
+Thumbs.db
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows shortcuts
+*.lnk
+
+### Linux
+# Backup files
+*~
+
+# Temporary files from deleted open files
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder
+.Trash-*
+
+# NFS temporary files
+.nfs*
+
+### VS Code
+# VSCode settings (keep shared configuration)
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### Go
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Go workspace file
+go.work.sum
+
+# env file
+.env

--- a/example/drawer/main.go
+++ b/example/drawer/main.go
@@ -21,7 +21,6 @@ import (
 	"image/color"
 	"image/draw"
 	"image/png"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -83,7 +82,7 @@ func main() {
 	flag.Parse()
 
 	// Read the font data.
-	fontBytes, err := ioutil.ReadFile(*fontfile)
+	fontBytes, err := os.ReadFile(*fontfile)
 	if err != nil {
 		log.Println(err)
 		return

--- a/example/freetype/main.go
+++ b/example/freetype/main.go
@@ -21,7 +21,6 @@ import (
 	"image/color"
 	"image/draw"
 	"image/png"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -79,7 +78,7 @@ func main() {
 	flag.Parse()
 
 	// Read the font data.
-	fontBytes, err := ioutil.ReadFile(*fontfile)
+	fontBytes, err := os.ReadFile(*fontfile)
 	if err != nil {
 		log.Println(err)
 		return

--- a/example/genbasicfont/main.go
+++ b/example/genbasicfont/main.go
@@ -22,9 +22,10 @@ import (
 	"go/format"
 	"image"
 	"image/draw"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"unicode"
 
@@ -48,9 +49,9 @@ func loadFontFile() ([]byte, error) {
 			return nil, err
 		}
 		defer resp.Body.Close()
-		return ioutil.ReadAll(resp.Body)
+		return io.ReadAll(resp.Body)
 	}
-	return ioutil.ReadFile(*fontfile)
+	return os.ReadFile(*fontfile)
 }
 
 func parseHinting(h string) font.Hinting {
@@ -233,7 +234,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("format.Source: %v", err)
 	}
-	if err := ioutil.WriteFile(*vr+".go", fmted, 0644); err != nil {
-		log.Fatalf("ioutil.WriteFile: %v", err)
+	if err := os.WriteFile(*vr+".go", fmted, 0644); err != nil {
+		log.Fatalf("os.WriteFile: %v", err)
 	}
 }

--- a/example/truetype/main.go
+++ b/example/truetype/main.go
@@ -16,8 +16,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/unidoc/freetype/truetype"
 	"golang.org/x/image/font"
@@ -51,7 +51,7 @@ func printGlyph(g *truetype.GlyphBuf) {
 func main() {
 	flag.Parse()
 	fmt.Printf("Loading fontfile %q\n", *fontfile)
-	b, err := ioutil.ReadFile(*fontfile)
+	b, err := os.ReadFile(*fontfile)
 	if err != nil {
 		log.Println(err)
 		return

--- a/freetype_test.go
+++ b/freetype_test.go
@@ -8,20 +8,20 @@ package freetype
 import (
 	"image"
 	"image/draw"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
 )
 
 func BenchmarkDrawString(b *testing.B) {
-	data, err := ioutil.ReadFile("licenses/gpl.txt")
+	data, err := os.ReadFile("licenses/gpl.txt")
 	if err != nil {
 		b.Fatal(err)
 	}
 	lines := strings.Split(string(data), "\n")
 
-	data, err = ioutil.ReadFile("testdata/luxisr.ttf")
+	data, err = os.ReadFile("testdata/luxisr.ttf")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/unidoc/freetype
 
-go 1.14
+go 1.18
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410

--- a/truetype/face_test.go
+++ b/truetype/face_test.go
@@ -8,7 +8,7 @@ package truetype
 import (
 	"image"
 	"image/draw"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -17,12 +17,12 @@ import (
 )
 
 func BenchmarkDrawString(b *testing.B) {
-	data, err := ioutil.ReadFile("../licenses/gpl.txt")
+	data, err := os.ReadFile("../licenses/gpl.txt")
 	if err != nil {
 		b.Fatal(err)
 	}
 	lines := strings.Split(string(data), "\n")
-	data, err = ioutil.ReadFile("../testdata/luxisr.ttf")
+	data, err = os.ReadFile("../testdata/luxisr.ttf")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/truetype/fuzz_test.go
+++ b/truetype/fuzz_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The Freetype-Go Authors. All rights reserved.
+// Use of this source code is governed by your choice of either the
+// FreeType License or the GNU General Public License version 2 (or
+// any later version), both of which can be found in the LICENSE file.
+
+package truetype
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/math/fixed"
+)
+
+// FuzzParse exercises Parse and GlyphBuf.Load with arbitrary input.
+// Seeds come from the bundled .ttf testdata; the fuzzer mutates them to
+// surface format/bounds bugs (e.g. issue 598-style OOB reads on
+// truncated or subsetted tables). A panic-free run for any input
+// constitutes the success criterion - Parse and Load are allowed to
+// return an error on malformed data, but never to panic.
+func FuzzParse(f *testing.F) {
+	seeds, err := filepath.Glob("../testdata/*.ttf")
+	if err != nil {
+		f.Fatalf("glob seed corpus: %v", err)
+	}
+	for _, p := range seeds {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		f.Add(b)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fnt, err := Parse(data)
+		if err != nil {
+			return
+		}
+		gb := &GlyphBuf{}
+		scale := fixed.Int26_6(fnt.FUnitsPerEm())
+		// Probe both in-range and clearly out-of-range indices so that
+		// loca/glyf/hmtx bounds checks are exercised on every input.
+		for _, i := range []Index{0, 1, 2, 32, 64, 1024, 65535} {
+			_ = gb.Load(fnt, scale, i, font.HintingNone)
+		}
+	})
+}

--- a/truetype/glyph.go
+++ b/truetype/glyph.go
@@ -6,6 +6,8 @@
 package truetype
 
 import (
+	"fmt"
+
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )
@@ -175,6 +177,21 @@ func (g *GlyphBuf) load(recursion uint32, i Index, useMyMetrics bool) (err error
 	if recursion >= 32 {
 		return UnsupportedError("excessive compound glyph recursion")
 	}
+	// Bounds-check the loca read so that a subset font referencing a glyph
+	// beyond loca's range, or a truncated loca table, does not panic.
+	// Out-of-range indices fall back to glyph 0 (.notdef), matching the
+	// placeholder behaviour of mainstream PDF viewers (e.g. Acrobat).
+	locaEntrySize := 4
+	if g.font.locaOffsetFormat == locaOffsetFormatShort {
+		locaEntrySize = 2
+	}
+	if int(i) < 0 || locaEntrySize*(int(i)+2) > len(g.font.loca) {
+		i = 0
+	}
+	if locaEntrySize*(int(i)+2) > len(g.font.loca) {
+		return FormatError(fmt.Sprintf("loca too short for glyph %d (len=%d)", i, len(g.font.loca)))
+	}
+
 	// Find the relevant slice of g.font.glyf.
 	var g0, g1 uint32
 	if g.font.locaOffsetFormat == locaOffsetFormatShort {
@@ -187,9 +204,10 @@ func (g *GlyphBuf) load(recursion uint32, i Index, useMyMetrics bool) (err error
 
 	// Decode the contour count and nominal bounding box, from the first
 	// 10 bytes of the glyf data. boundsYMin and boundsXMax, at offsets 4
-	// and 6, are unused.
+	// and 6, are unused. Also guard against loca offsets that point past
+	// the end of glyf (defense in depth against malformed subset fonts).
 	glyf, ne, boundsXMin, boundsYMax := []byte(nil), 0, fixed.Int26_6(0), fixed.Int26_6(0)
-	if g0+10 <= g1 {
+	if g0+10 <= g1 && uint64(g1) <= uint64(len(g.font.glyf)) {
 		glyf = g.font.glyf[g0:g1]
 		ne = int(int16(u16(glyf, 0)))
 		boundsXMin = fixed.Int26_6(int16(u16(glyf, 2)))

--- a/truetype/truetype.go
+++ b/truetype/truetype.go
@@ -578,15 +578,22 @@ func printable(r uint16) byte {
 // the given index.
 func (f *Font) unscaledHMetric(i Index) (h HMetric) {
 	j := int(i)
-	if j < 0 || f.nGlyph <= j {
+	if j < 0 || f.nGlyph <= j || f.nHMetric <= 0 {
 		return HMetric{}
 	}
 	if j >= f.nHMetric {
 		p := 4 * (f.nHMetric - 1)
+		q := p + 2*(j-f.nHMetric) + 4
+		if p+2 > len(f.hmtx) || q+2 > len(f.hmtx) {
+			return HMetric{}
+		}
 		return HMetric{
 			AdvanceWidth:    fixed.Int26_6(u16(f.hmtx, p)),
-			LeftSideBearing: fixed.Int26_6(int16(u16(f.hmtx, p+2*(j-f.nHMetric)+4))),
+			LeftSideBearing: fixed.Int26_6(int16(u16(f.hmtx, q))),
 		}
+	}
+	if 4*j+4 > len(f.hmtx) {
+		return HMetric{}
 	}
 	return HMetric{
 		AdvanceWidth:    fixed.Int26_6(u16(f.hmtx, 4*j)),

--- a/truetype/truetype_test.go
+++ b/truetype/truetype_test.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -20,7 +19,7 @@ import (
 )
 
 func parseTestdataFont(name string) (f *Font, testdataIsOptional bool, err error) {
-	b, err := ioutil.ReadFile(fmt.Sprintf("../testdata/%s.ttf", name))
+	b, err := os.ReadFile(fmt.Sprintf("../testdata/%s.ttf", name))
 	if err != nil {
 		// The "x-foo" fonts are optional tests, as they are not checked
 		// in for copyright or file size reasons.


### PR DESCRIPTION
Fixes the index-out-of-range panic reported in unidoc/unipdf#598, where a subsetted TrueType font's `/W` array references CIDs beyond the `loca` table. (*GlyphBuf).load now bounds-checks `loca`/`glyf` reads and falls back to glyph 0 (`.notdef`) for out-of-range indices, matching the placeholder behaviour of mainstream PDF viewers. `unscaledHMetric` gets matching bounds checks against `hmtx` for malformed fonts.

Also bumps the go directive to 1.18, migrates off the deprecated `io`/`ioutil`, and adds a FuzzParse target seeded from the bundled testdata to catch similar bugs going forward.